### PR TITLE
feat: CSVファイルアップロード機能の改善とpydanticバリデーターの更新

### DIFF
--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, Field, field_validator
 import re
 
 
@@ -9,24 +9,24 @@ class UserBase(BaseModel):
 class UserCreate(UserBase):
     password: str
 
-    @validator("password")
-    def validate_password(cls, v):
-        # 最小8文字
-        if len(v) < 8:
-            raise ValueError("パスワードは8文字以上で入力してください。")
-        # 英大文字・小文字・数字・記号のいずれか3種以上を含む
-        count = 0
-        if re.search(r"[A-Z]", v):
-            count += 1
-        if re.search(r"[a-z]", v):
-            count += 1
-        if re.search(r"[0-9]", v):
-            count += 1
-        if re.search(r"[^A-Za-z0-9]", v):
-            count += 1
-        if count < 3:
-            raise ValueError("パスワードは英大文字・小文字・数字・記号のうち3種類以上を含めてください。")
-        return v
+    # @field_validator("password")
+    # def validate_password(cls, v):
+    #     # 最小8文字
+    #     if len(v) < 8:
+    #         raise ValueError("パスワードは8文字以上で入力してください。")
+    #     # 英大文字・小文字・数字・記号のいずれか3種以上を含む
+    #     count = 0
+    #     if re.search(r"[A-Z]", v):
+    #         count += 1
+    #     if re.search(r"[a-z]", v):
+    #         count += 1
+    #     if re.search(r"[0-9]", v):
+    #         count += 1
+    #     if re.search(r"[^A-Za-z0-9]", v):
+    #         count += 1
+    #     if count < 3:
+    #         raise ValueError("パスワードは英大文字・小文字・数字・記号のうち3種類以上を含めてください。")
+    #     return v
 
 
 class User(UserBase):

--- a/front/src/components/elements/ReadCsv.js
+++ b/front/src/components/elements/ReadCsv.js
@@ -1,32 +1,35 @@
-import React from 'react'
-import Papa from 'papaparse'
-import ReactFileReader from 'react-file-reader'
-import Button from '@mui/material/Button'
+import Papa from "papaparse";
+import ReactFileReader from "react-file-reader";
+import Button from "@mui/material/Button";
+import { useCreateSales } from "../hooks/useCreateSales";
 
 export const ReadCsv = ({ handleDataChange }) => {
+  const { onClickCreateSales } = useCreateSales();
+
   const uploadFile = (files) => {
-    const file = files[0]
+    const file = files[0];
     Papa.parse(file, {
-      header: true,
+      header: false, // ヘッダーとして解析せず、配列の配列として取得
       skipEmptyLines: true,
       complete: (results) => {
-        console.log(results.data)
-        handleDataChange(results.data)
+        console.log("Raw CSV data:", results.data);
+        onClickCreateSales(results.data);
+        handleDataChange(results.data);
       },
       error: (error) => {
-        console.error("Error parsing CSV:", error)
-      }
-    })
-  }
+        console.error("Error parsing CSV:", error);
+      },
+    });
+  };
 
   return (
     <>
       <ReactFileReader handleFiles={uploadFile} fileTypes={[".csv"]}>
         <Button variant="contained" component="span">
           CSVファイルを選択
-        </Button> 
+        </Button>
       </ReactFileReader>
       <p>CSVファイルを選択して、データベースに格納します。</p>
     </>
-  )
-}
+  );
+};

--- a/front/src/components/hooks/useCreateSales.js
+++ b/front/src/components/hooks/useCreateSales.js
@@ -1,0 +1,25 @@
+import axios from "axios";
+
+export const useCreateSales = () => {
+  const onClickCreateSales = async (data) => {
+    const endpoint = "http://127.0.0.1:8000/sales";
+    try {
+      // 1列目から最後の列まで処理（0列目はヘッダーなのでスキップ）
+      for (let i = 1; i < data[0].length; i++) {
+        const queries = {
+          year: Number(data[1][i]),
+          department: data[0][i],
+          sales: Number(data[2][i]),
+        };
+        await axios.post(endpoint, queries);
+      }
+    }
+    catch (error) {
+      console.error("Error sending data to API:", error);
+    }
+  };
+
+  return {
+    onClickCreateSales
+  };
+}


### PR DESCRIPTION
- ReadCsv.jsでheaderをfalseに設定し、配列の配列として取得するように変更
- useCreateSales.jsフックを新規作成し、CSVデータをバックエンドAPIに送信する機能を実装
- schemas.pyでpydanticのvalidatorをfield_validatorに更新（一時的にコメントアウト）
- CSVファイルの各列を部門として処理し、年度と売上データをAPIに送信

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added the ability to process and upload CSV sales data directly from the interface, enabling users to send multiple sales records to the backend in one action.

- **Bug Fixes**
	- Adjusted CSV parsing to treat all rows as data (not using headers), ensuring correct data processing during upload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->