### PR TITLE
Fix login state variable name

### DIFF
--- a/front/src/components/pages/Home.js
+++ b/front/src/components/pages/Home.js
@@ -8,7 +8,7 @@ import { SelectYear } from "../elements/SelectYear";
 import { ReadDatabase } from "../elements/ReadDatabase";
 
 export const Home = () => {
-  const { isLogined } = useContext(LoginUserProviderContext);
+  const { isLoggedIn } = useContext(LoginUserProviderContext);
   const [year, setYear] = useState("");
   const [data, setData] = useState([]);
 
@@ -24,7 +24,7 @@ export const Home = () => {
     setData(newData);
   }, []);
 
-  if (!isLogined) {
+  if (!isLoggedIn) {
     return <Navigate to="/login" />;
   } else {
     return (

--- a/front/src/components/providers/LoginUserProvider.js
+++ b/front/src/components/providers/LoginUserProvider.js
@@ -6,10 +6,10 @@ export const LoginUserProviderContext = createContext({});
 export const LoginUserProvider = (props) => {
   const { children } = props;
   const [loginUser, setLoginUser] = useState("");
-  const [isLogined, setIsLoggedIn] = useState(false);
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
 
   return (
-    <LoginUserProviderContext.Provider value={{ loginUser, setLoginUser, isLogined, setIsLoggedIn }}>
+    <LoginUserProviderContext.Provider value={{ loginUser, setLoginUser, isLoggedIn, setIsLoggedIn }}>
       {children}
     </LoginUserProviderContext.Provider>
   )


### PR DESCRIPTION
## Summary
- rename `isLogined` to `isLoggedIn`
- update home page to use new login state variable

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: httpx)*
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_b_684640da03cc832ca5eec513cd53ac9b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Corrected the naming of the login status variable for consistency across the application. No changes to functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->