### PR TITLE
fix: Update GitHub Actions workflow to use main branch instead of master

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,11 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(gh issue list:*)",
+      "Bash(gh issue view:*)",
+      "Bash(git checkout:*)",
+      "Bash(git add:*)"
+    ],
+    "deny": []
+  }
+}

--- a/.github/workflows/create-pr-to-master.yaml
+++ b/.github/workflows/create-pr-to-master.yaml
@@ -1,4 +1,4 @@
-name: Create PR from develop to master
+name: Create PR from develop to main
 
 on:
   # developブランチへのプッシュ時に実行
@@ -25,23 +25,23 @@ jobs:
 
       - name: Create Pull Request if not exists
         run: |
-          # developブランチがmasterと同じでない場合のみPRを作成
-          if ! git diff --quiet origin/develop origin/master; then
+          # developブランチがmainと同じでない場合のみPRを作成
+          if ! git diff --quiet origin/develop origin/main; then
             # 既存のPRがあるか確認
-            PR_EXISTS=$(gh pr list --base master --head develop --json number | grep -c "number" || echo "0")
+            PR_EXISTS=$(gh pr list --base main --head develop --json number | grep -c "number" || echo "0")
             
             if [ "$PR_EXISTS" -eq "0" ]; then
-              echo "Creating new PR from develop to master"
+              echo "Creating new PR from develop to main"
               gh pr create \
-                --base master \
+                --base main \
                 --head develop \
-                --title "【自動PR】developからmasterへの更新" \
-                --body "developブランチの変更をmasterブランチにマージするための自動プルリクエストです。"
+                --title "【自動PR】developからmainへの更新" \
+                --body "developブランチの変更をmainブランチにマージするための自動プルリクエストです。"
             else
-              echo "PR from develop to master already exists"
+              echo "PR from develop to main already exists"
             fi
           else
-            echo "No changes between develop and master branches"
+            echo "No changes between develop and main branches"
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Changed all references from master to main branch in GitHub Actions workflow
- Fixed automatic PR creation from develop to main branch  
- Resolves issue #14: develop→mainへのPRが自動で作成されない

## Changes
- Updated `.github/workflows/create-pr-to-master.yaml` to reference `main` branch instead of `master`
- Fixed workflow name and all branch references throughout the file

## Test plan
- [x] Updated workflow file with correct branch names
- [x] Verified remote branches to confirm main is the default branch
- [ ] Test workflow execution on next push to develop branch

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated workflow configuration to use "main" as the target branch instead of "master" in all relevant references.
  - Added a local settings file to define permitted command executions for certain GitHub and Git operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->