### PR TITLE
Fix tests to match user API

### DIFF
--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -1,33 +1,41 @@
+import pytest
 from fastapi.testclient import TestClient
 
 from backend.main import app
 
-client = TestClient(app)
+
+@pytest.fixture(scope="module")
+def client():
+    # start each test module with a clean database
+    from backend.database import sqlite_file_name
+    if sqlite_file_name.exists():
+        sqlite_file_name.unlink()
+    with TestClient(app) as c:
+        yield c
 
 
-def test_read_root():
-    response = client.get("/")
-    assert response.status_code == 200
-    assert response.json() == {"message": "Welcome to the Hero API"}
-
-
-def test_create_hero():
-    hero_data = {
-        "name": "テスト勇者",
-        "secret_name": "秘密の名前",
-        "age": 25
+def test_create_user(client):
+    user_data = {
+        "name": "テストユーザー",
+        "password": "secret"
     }
-    response = client.post("/heroes/", json=hero_data)
+    response = client.post("/users/", json=user_data)
     assert response.status_code == 200
-    assert response.json()["name"] == hero_data["name"]
-    assert response.json()["secret_name"] == hero_data["secret_name"]
-    assert response.json()["age"] == hero_data["age"]
+    assert response.json()["name"] == user_data["name"]
+    assert response.json()["is_active"] is True
     assert "id" in response.json()
 
 
-def test_read_heroes():
-    response = client.get("/heroes/")
+def test_read_users(client):
+    response = client.get("/users/")
     assert response.status_code == 200
     assert isinstance(response.json(), list)
-    # 少なくとも1つのヒーローが存在することを確認（前のテストで作成されたもの）
+    # 前のテストでユーザーが作成されているはずなので1件以上存在することを確認
     assert len(response.json()) > 0
+
+
+def test_read_user(client):
+    params = {"name": "テストユーザー", "password": "secret"}
+    response = client.get("/user", params=params)
+    assert response.status_code == 200
+    assert response.json()["name"] == params["name"]


### PR DESCRIPTION
## Summary
- update tests to use `/users` endpoint since heroes router isn't included
- reset the SQLite DB in tests to avoid conflicts

## Testing
- `poetry run python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6853c5458560832cbe266f3472d9cbb3