### PR TITLE
Allow Vite dev server

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -21,6 +21,7 @@ app = FastAPI(lifespan=lifespan)
 
 origins = [
     "http://localhost:3000",
+    "http://localhost:5173",
 ]
 
 app.add_middleware(


### PR DESCRIPTION
## Summary
- update CORS origins list to include `http://localhost:5173`

## Testing
- `poetry run pytest tests/test_main.py -vv` *(fails: 3 failing tests)*

------
https://chatgpt.com/codex/tasks/task_b_6853c5430884832c8cdf2226ac3ffffb