### PR TITLE
Add backend README for Poetry install

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,18 @@
+# FastAPI Backend
+
+This directory contains the FastAPI backend for the demo sales management application.
+
+## Development
+
+Install dependencies and run the development server:
+
+```bash
+poetry install
+poetry run uvicorn backend.main:app --reload --host 127.0.0.1 --port 8000
+```
+
+Run tests with:
+
+```bash
+poetry run pytest
+```


### PR DESCRIPTION
## Summary
- add a small README under `backend/` to satisfy Poetry's `readme` field

## Testing
- `poetry run pytest -q` *(fails: 3 tests failed)*

------
https://chatgpt.com/codex/tasks/task_b_6853c547cf6c832ca737237a5f3f9bc1