### PR TITLE
Implement password validation

### DIFF
--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -9,24 +9,27 @@ class UserBase(BaseModel):
 class UserCreate(UserBase):
     password: str
 
-    # @field_validator("password")
-    # def validate_password(cls, v):
-    #     # 最小8文字
-    #     if len(v) < 8:
-    #         raise ValueError("パスワードは8文字以上で入力してください。")
-    #     # 英大文字・小文字・数字・記号のいずれか3種以上を含む
-    #     count = 0
-    #     if re.search(r"[A-Z]", v):
-    #         count += 1
-    #     if re.search(r"[a-z]", v):
-    #         count += 1
-    #     if re.search(r"[0-9]", v):
-    #         count += 1
-    #     if re.search(r"[^A-Za-z0-9]", v):
-    #         count += 1
-    #     if count < 3:
-    #         raise ValueError("パスワードは英大文字・小文字・数字・記号のうち3種類以上を含めてください。")
-    #     return v
+    @field_validator("password")
+    def validate_password(cls, v: str) -> str:
+        """Validate password complexity."""
+        # 最小8文字
+        if len(v) < 8:
+            raise ValueError("パスワードは8文字以上で入力してください。")
+        # 英大文字・小文字・数字・記号のいずれか3種以上を含む
+        count = 0
+        if re.search(r"[A-Z]", v):
+            count += 1
+        if re.search(r"[a-z]", v):
+            count += 1
+        if re.search(r"[0-9]", v):
+            count += 1
+        if re.search(r"[^A-Za-z0-9]", v):
+            count += 1
+        if count < 3:
+            raise ValueError(
+                "パスワードは英大文字・小文字・数字・記号のうち3種類以上を含めてください。"
+            )
+        return v
 
 
 class User(UserBase):

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -28,7 +28,7 @@ def client_fixture():
 
 
 def test_create_and_read_user(client):
-    user_data = {"name": "alice", "password": "secret"}
+    user_data = {"name": "alice", "password": "Secret12!"}
     response = client.post("/users/", json=user_data)
     assert response.status_code == 200
     data = response.json()
@@ -43,11 +43,17 @@ def test_create_and_read_user(client):
 
 
 def test_create_duplicate_user(client):
-    user_data = {"name": "bob", "password": "secret"}
+    user_data = {"name": "bob", "password": "Secret12!"}
     res1 = client.post("/users/", json=user_data)
     assert res1.status_code == 200
     res2 = client.post("/users/", json=user_data)
     assert res2.status_code == 400
+
+
+def test_create_user_invalid_password(client):
+    invalid_data = {"name": "charlie", "password": "short"}
+    res = client.post("/users/", json=invalid_data)
+    assert res.status_code == 422
 
 
 def test_create_and_read_sales(client):


### PR DESCRIPTION
## Summary
- add password validation for UserCreate schema
- update user tests for new rules and add invalid password test

## Testing
- `cd backend && poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_687b6255cf08832ca9cd996f35272ea6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced password complexity requirements for user creation, ensuring stronger passwords.
* **Tests**
  * Updated user creation tests to use complex passwords.
  * Added a test to verify that weak passwords are rejected during user registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->